### PR TITLE
[NEX-6555] Make gem compatible with Ruby 3

### DIFF
--- a/app/helpers/smart_listing/helper.rb
+++ b/app/helpers/smart_listing/helper.rb
@@ -46,7 +46,7 @@ module SmartListing
 
       def paginate options = {}
         if @smart_listing.collection.respond_to? :current_page
-          @template.paginate @smart_listing.collection, {:remote => @smart_listing.remote?, :param_name => @smart_listing.param_name(:page)}.merge(@smart_listing.kaminari_options)
+          @template.paginate @smart_listing.collection, **{:remote => @smart_listing.remote?, :param_name => @smart_listing.param_name(:page)}.merge(@smart_listing.kaminari_options)
         end
       end
 

--- a/lib/smart_listing.rb
+++ b/lib/smart_listing.rb
@@ -109,7 +109,7 @@ module SmartListing
       else
         # let's sort by all attributes
         #
-        @collection = @collection.order(sort_keys.collect{|s| "#{s[1]} #{@sort[s[0]]}" if @sort[s[0]]}.compact) if @sort && !@sort.empty?
+        @collection = @collection.order(sort_keys.collect{|s| Arel.sql("#{s[1]} #{@sort[s[0]]}") if @sort[s[0]]}.compact) if @sort && !@sort.empty?
 
         if @options[:paginate] && @per_page > 0
           @collection = @collection.page(@page).per(@per_page)


### PR DESCRIPTION
Makes this fork of [smart_listing](https://github.com/Sology/smart_listing) compatible with Ruby 3. This is based on [this example PR](https://github.com/Sology/smart_listing/pull/231) in the original repo