### PR TITLE
fix: use require_relative for helper

### DIFF
--- a/app/helpers/smart_listing/application_helper.rb
+++ b/app/helpers/smart_listing/application_helper.rb
@@ -1,4 +1,4 @@
-require 'smart_listing/helper'
+require_relative './helper'
 module SmartListing
   module ApplicationHelper
   end


### PR DESCRIPTION
To resolve this error on Rails 7.1:

```
LoadError:
  cannot load such file -- smart_listing/helper
```

https://optimere.atlassian.net/browse/NEX-9198